### PR TITLE
Bugfix givemeasign caskofrosewine

### DIFF
--- a/The Cask of Rose Wine/EtchedPottery.cs
+++ b/The Cask of Rose Wine/EtchedPottery.cs
@@ -66,7 +66,7 @@ namespace XRL.World.Parts
         // Show the contents of the book, appending the text of the secret.
 				BookUI.ShowBook(this.bookText + this.secret.text, this.ParentObject.DisplayName);
         // Reveal the secret to the player.
-				this.secret?.Reveal(false);
+				this.secret?.Reveal();
 			}
 			return base.HandleEvent(E);
 		}

--- a/The Cask of Rose Wine/FortunadoSpawnerSystem.cs
+++ b/The Cask of Rose Wine/FortunadoSpawnerSystem.cs
@@ -9,6 +9,8 @@ namespace XRL
   [Serializable]
   public class Gearlink_CASKOFROSEWINE_FortunadoSpawnerSystem : IGameSystem
   {
+    /* Because this IGameSystem is Serializable, spawned will persist across
+    the game being saved and loaded. */
     public bool spawned = false;
 
     public int chance = 1;
@@ -19,9 +21,22 @@ namespace XRL
     to it. */
     public Dictionary<string, bool> Visited = new Dictionary<string, bool>();
 
-    /* Override this virtual method of IGameSystem so this system will do something
-    whenever a zone is activated. */
-    public override void ZoneActivated(Zone zone) => this.CheckFortunadoSpawn(zone);
+    /* Register the ZoneActivatedEvent with this system so it can do something
+    when a new zone activates. */
+    public override void Register(XRLGame Game, IEventRegistrar Registrar)
+    {
+      /* Only register if the system hasn't yet spawned Fortunado's remains. */
+      if ( !this.spawned )
+        Registrar.Register(ZoneActivatedEvent.ID);
+    }
+
+    /* Check if Fortunado's remains should be spawned each time a new zone
+    activates. */
+    public override bool HandleEvent(ZoneActivatedEvent E)
+    {
+      this.CheckFortunadoSpawn(E.Zone);
+      return base.HandleEvent(E);
+    }
 
     /* While string, int, and bool properties can just be marked as [Serializable]
     to persist across the game being saved and loaded, more complicated data
@@ -43,6 +58,11 @@ namespace XRL
       if (chance.in100())
       {
         new Gearlink_CASKOFROSEWINE_FortunadoSpawnerBuilder().BuildZone( zone );
+        /* Since we don't plan on spawning anymore, unregister from the
+        ZoneActivatedEvent so this check doesn't run. */
+        this.UnregisterEvent(ZoneActivatedEvent.ID);
+        /* Still need to set spawned to true so the system knows it's already
+        spawned next time the game is loaded. */
         this.spawned = true;
       }
     }


### PR DESCRIPTION
`Gearlink_GIVEMEASIGN_LoveDrunkSignSpawnerSystem ` and `Gearlink_CASKOFROSEWINE_FortunadoSpawnerSystem ` have been updated to use the minimal event system instead of overriding the obsolete function `IGameSystem.ZoneActivated`.

Also fixed a bug in `Gearlink_CASKOFROSEWINE_EtchedPottery` that caused an error when loading the Cask of Rose Wine mod.
 